### PR TITLE
Save extended metadata to tag

### DIFF
--- a/Dukebox.Desktop/ViewModel/MetadataColumnsSettingsViewModel.cs
+++ b/Dukebox.Desktop/ViewModel/MetadataColumnsSettingsViewModel.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Dukebox.Desktop.Interfaces;
 using Dukebox.Desktop.Model;
 using Dukebox.Library.Factories;
+using Dukebox.Library.Helper;
 
 namespace Dukebox.Desktop.ViewModel
 {
@@ -16,9 +16,8 @@ namespace Dukebox.Desktop.ViewModel
         public MetadataColumnsSettingsViewModel(IDukeboxUserSettings userSettings, AudioFileMetadataFactory audioFileMetadataFactory)
         {
             _userSettings = userSettings;
-
-            var metadataTagType = audioFileMetadataFactory.GetConcreteMetadataTagType();
-            PopulateMetadataColumns(metadataTagType);
+            
+            PopulateMetadataColumns();
 
             MetadataColumns.ForEach(s => s.PropertyChanged += 
                 (o, e) => UpdateMetadatColumnSetting(o as ExtendedMetadataColumnSetting)); ;
@@ -46,13 +45,12 @@ namespace Dukebox.Desktop.ViewModel
             SendNotificationMessage(NotificationMessages.TrackListingDataGridColumnsUpdated);
         }
 
-        private void PopulateMetadataColumns(Type metadataTagType)
+        private void PopulateMetadataColumns()
         {
-            MetadataColumns = metadataTagType
-                .GetProperties()
-                .Where(p => p.CanRead)
-                .OrderBy(p => p.Name)
-                .Select(p => new ExtendedMetadataColumnSetting { ColumnName = p.Name, IsEnabled = IsMetadataColumnEnabled(p.Name) })
+            MetadataColumns = ExtendedMetadataHelper
+                .MetadataPropertyNames
+                .OrderBy(p => p)
+                .Select(p => new ExtendedMetadataColumnSetting { ColumnName = p, IsEnabled = IsMetadataColumnEnabled(p) })
                 .ToList();
         }
 

--- a/Dukebox.Library/Dukebox.Library.csproj
+++ b/Dukebox.Library/Dukebox.Library.csproj
@@ -142,6 +142,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Factories\AudioFileMetadataFactory.cs" />
+    <Compile Include="Helper\ExtendedMetadataHelper.cs" />
     <Compile Include="Helper\StringToFilenameConverter.cs" />
     <Compile Include="Interfaces\IMusicLibraryImportService.cs" />
     <Compile Include="Interfaces\IMusicLibraryUpdateService.cs" />

--- a/Dukebox.Library/Helper/ExtendedMetadataHelper.cs
+++ b/Dukebox.Library/Helper/ExtendedMetadataHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TagLib;
+
+namespace Dukebox.Library.Helper
+{
+    public static class ExtendedMetadataHelper
+    {
+        private static readonly Type audioTagType = typeof(Tag);
+        private static readonly List<string> protectedTagProperties = new List<string> { "Title", "Performers", "Album" };
+
+        private static readonly List<PropertyInfo> readableProperties = audioTagType.GetProperties()
+            .Where(p => !protectedTagProperties.Contains(p.Name) && p.CanRead)
+            .ToList();
+        private static readonly List<PropertyInfo> writableProperties = audioTagType.GetProperties()
+            .Where(p => !protectedTagProperties.Contains(p.Name) && p.CanWrite)
+            .ToList();
+
+        public static readonly List<string> MetadataPropertyNames = readableProperties.Select(p => p.Name).ToList();
+
+        public static Dictionary<string, List<string>> ReadExtendedMetadata(Tag tag)
+        {
+            var extendedMetadata = new Dictionary<string, List<string>>();
+
+            foreach (var property in readableProperties)
+            {
+                var values = property.PropertyType.IsArray ?
+                        ((object[])property.GetValue(tag))?.Select(o => o.ToString())?.ToList() ?? new List<string>()
+                    : new List<string> { property.GetValue(tag)?.ToString() ?? string.Empty };
+
+                var validValues = values.Where(s => !string.IsNullOrEmpty(s)).ToList();
+
+                if (validValues.Any())
+                {
+                    extendedMetadata[property.Name] = validValues;
+                }
+            }
+
+            return extendedMetadata;
+        }
+
+        public static void WriteExtendedMetadata(Tag tag, Dictionary<string, List<string>> extendedMetadata)
+        {
+            foreach (var property in writableProperties)
+            {
+                var propertyName = property.Name;
+
+                if (!extendedMetadata.ContainsKey(propertyName) ||
+                    !extendedMetadata[propertyName].Any())
+                {
+                    continue;
+                }
+
+                var extendedMetadataValue = extendedMetadata[propertyName];
+                var propertyType = property.PropertyType;
+
+                if (property.PropertyType.IsArray)
+                {
+                    var values = extendedMetadataValue.Select(v => Convert.ChangeType(v, propertyType)).ToArray();
+                    property.SetValue(tag, values);
+                }
+                else
+                {
+                    var value = Convert.ChangeType(extendedMetadataValue.First(), propertyType);
+                    property.SetValue(tag, value);
+                }
+            }
+        }
+    }
+}

--- a/Dukebox.Library/Helper/ExtendedMetadataHelper.cs
+++ b/Dukebox.Library/Helper/ExtendedMetadataHelper.cs
@@ -9,7 +9,18 @@ namespace Dukebox.Library.Helper
     public static class ExtendedMetadataHelper
     {
         private static readonly Type audioTagType = typeof(Tag);
-        private static readonly List<string> protectedTagProperties = new List<string> { "Title", "Performers", "Album" };
+        private static readonly List<string> protectedTagProperties = new List<string>
+        {
+            "Title",
+            "TitleSort",
+            "Artists",
+            "AlbumArtists",
+            "AlbumArtistsSort",
+            "Performers",
+            "PerformersSort",
+            "Album",
+            "Pictures"
+        };
 
         private static readonly List<PropertyInfo> readableProperties = audioTagType.GetProperties()
             .Where(p => !protectedTagProperties.Contains(p.Name) && p.CanRead)
@@ -58,8 +69,13 @@ namespace Dukebox.Library.Helper
 
                 if (property.PropertyType.IsArray)
                 {
-                    var values = extendedMetadataValue.Select(v => Convert.ChangeType(v, propertyType)).ToArray();
-                    property.SetValue(tag, values);
+                    var elementType = propertyType.GetElementType();
+                    var values = extendedMetadataValue.Select(v => Convert.ChangeType(v, elementType)).ToArray();
+                    var arrayValue = Array.CreateInstance(elementType, values.Length);
+
+                    Array.Copy(values, arrayValue, values.Length);
+
+                    property.SetValue(tag, arrayValue);
                 }
                 else
                 {

--- a/Dukebox.Library/Services/AudioFileMetaData.cs
+++ b/Dukebox.Library/Services/AudioFileMetaData.cs
@@ -2,11 +2,13 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using log4net;
 using TagLib;
 using Dukebox.Library.Interfaces;
 using Dukebox.Library.Model;
+using Dukebox.Library.Helper;
 
 namespace Dukebox.Library.Services
 {
@@ -20,7 +22,8 @@ namespace Dukebox.Library.Services
             "Unable to get audio length: there is no metadata tag for audio file '{0}', defaulting to 0";
 
         private static readonly ILog logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-                        
+        private static readonly Type audioTagType = typeof(Tag);
+
         private readonly long _dbAlbumId;
         private readonly int _trackLength;
         private readonly bool _hasAlbumArt;
@@ -203,6 +206,8 @@ namespace Dukebox.Library.Services
                     tag.Title = Title;
                     tag.Performers = new string[] { Artist };
                     tag.Album = Album;
+
+                    ExtendedMetadataHelper.WriteExtendedMetadata(tag, ExtendedMetadata);
 
                     tagFile.Save();
 

--- a/Dukebox.Tests/Unit/AudioFileMetaDataTests.cs
+++ b/Dukebox.Tests/Unit/AudioFileMetaDataTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -129,16 +130,19 @@ namespace Dukebox.Tests.Unit
             var newTitle = "UnqiueTitle";
             var newArtist = "UniqueArtist";
             var newAlbum = "UnqiueAlbum";
+            var newYear = "1999";
 
             audioFileMetadata.Title = newTitle;
             audioFileMetadata.Artist = newArtist;
             audioFileMetadata.Album = newAlbum;
+            audioFileMetadata.ExtendedMetadata["Year"] = new List<string> { newYear };
 
             audioFileMetadata.SaveMetadataToFileTag();
 
             audioFileMetadata = _audioFileMetadataFactory.BuildAudioFileMetadataInstance(sampleForEditingMp3FileName);
 
-            var metadataCorrect = audioFileMetadata.Title == newTitle && audioFileMetadata.Artist == newArtist && audioFileMetadata.Album == newAlbum;
+            var metadataCorrect = audioFileMetadata.Title == newTitle && audioFileMetadata.Artist == newArtist 
+                && audioFileMetadata.Album == newAlbum && audioFileMetadata.ExtendedMetadata["Year"].First().Equals(newYear);
 
             Assert.True(metadataCorrect, "Failed to save and retrieve correct audio file metadata");
         }

--- a/Dukebox.Tests/Unit/MusicLibraryTests.cs
+++ b/Dukebox.Tests/Unit/MusicLibraryTests.cs
@@ -439,8 +439,16 @@ namespace Dukebox.Tests.Unit
         {
             var tracks = _musicLibrarySearchService.SearchForTracks("wish you were here", new List<SearchAreas> { SearchAreas.Song });
             var track = tracks.First();
+            var signalEvent = new ManualResetEvent(false);
+
+            _musicLibraryEventService.CachesRefreshed += (o, e) =>
+            {
+                signalEvent.Set();
+            };
 
             await _musicLibaryUpdateService.RemoveTrack(track);
+
+            signalEvent.WaitOne(1000);
 
             tracks = _musicLibrarySearchService.GetTracksByAttributeId(SearchAreas.Song, track.Song.Id.ToString());
             var trackDeleted = !tracks.Any();


### PR DESCRIPTION
- Added Helper for Extended Metadata
- Removed a few Properties from Extended Metadata as they are used for title/artist/album/album art
- Metadata is now saved to tag with title/artist/album
