### PR TITLE
Adding Inital Import UI

### DIFF
--- a/Dukebox.Desktop/DesktopContainer.cs
+++ b/Dukebox.Desktop/DesktopContainer.cs
@@ -29,6 +29,7 @@ namespace Dukebox.Desktop
 
             // window view model
             container.RegisterSingleton<ILoadingScreenViewModel, LoadingScreenViewModel>();
+            container.RegisterSingleton<IInitalImportWindowViewModel, InitalImportWindowViewModel>();
             container.RegisterSingleton<IMainWindowViewModel, MainWindowViewModel>();
             container.RegisterSingleton<IMetadataColumnsSettingsViewModel, MetadataColumnsSettingsViewModel>();
             container.RegisterSingleton<IWatchFolderSettingsViewModel, WatchFolderSettingsViewModel>();

--- a/Dukebox.Desktop/Dukebox.Desktop.csproj
+++ b/Dukebox.Desktop/Dukebox.Desktop.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Interfaces\IAudioDriveListingViewModel.cs" />
     <Compile Include="Interfaces\IMetadataColumnsSettingsViewModel.cs" />
     <Compile Include="Interfaces\IPlaylistListingViewModel.cs" />
+    <Compile Include="Interfaces\IProgressMonitorViewModel.cs" />
     <Compile Include="Interfaces\ISettingsMenuViewModel.cs" />
     <Compile Include="Interfaces\IWatchFolderSettingsViewModel.cs" />
     <Compile Include="Model\ExtendedMetadataColumnSetting.cs" />
@@ -187,7 +188,7 @@
     <Compile Include="Interfaces\IArtistListingViewModel.cs" />
     <Compile Include="Interfaces\ILoadingScreenViewModel.cs" />
     <Compile Include="Interfaces\IPlaybackMonitorViewModel.cs" />
-    <Compile Include="Interfaces\IProgressMonitorViewModel.cs" />
+    <Compile Include="Interfaces\IInitalImportWindowViewModel.cs" />
     <Compile Include="Interfaces\ISearchControlViewModel.cs" />
     <Compile Include="LoadingScreen.xaml.cs">
       <DependentUpon>LoadingScreen.xaml</DependentUpon>
@@ -214,6 +215,7 @@
     <Compile Include="Interfaces\IHelpMenuViewModel.cs" />
     <Compile Include="Interfaces\IPlaybackMenuViewModel.cs" />
     <Compile Include="Interfaces\IPlaylistMenuViewModel.cs" />
+    <Compile Include="ViewModel\InitalImportWindowViewModel.cs" />
     <Compile Include="ViewModel\InputPromptViewModel.cs" />
     <Compile Include="ViewModel\LoadingScreenViewModel.cs" />
     <Compile Include="ViewModel\MetadataColumnsSettingsViewModel.cs" />
@@ -250,6 +252,9 @@
     </Compile>
     <Compile Include="Views\PlaylistListing.xaml.cs">
       <DependentUpon>PlaylistListing.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\InitalImportWindow.xaml.cs">
+      <DependentUpon>InitalImportWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\ProgressMonitor.xaml.cs">
       <DependentUpon>ProgressMonitor.xaml</DependentUpon>
@@ -306,6 +311,10 @@
     <Page Include="Views\PlaylistListing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\InitalImportWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\ProgressMonitor.xaml">
       <SubType>Designer</SubType>

--- a/Dukebox.Desktop/DukeboxUserSettings.cs
+++ b/Dukebox.Desktop/DukeboxUserSettings.cs
@@ -79,6 +79,14 @@ namespace Dukebox.Desktop
         public DukeboxUserSettings()
         {
             _settings = Settings.Default;
+
+#if DEBUG 
+            _settings.repeat = false;
+            _settings.repeatAll = false;
+            _settings.shuffle = false;
+            _settings.extendedMetadataColumnsToShow = "Year";
+            _settings.initalImportHasBeenShown = false;
+#endif
         }
     }
 }

--- a/Dukebox.Desktop/DukeboxUserSettings.cs
+++ b/Dukebox.Desktop/DukeboxUserSettings.cs
@@ -62,6 +62,20 @@ namespace Dukebox.Desktop
             }
         }
 
+        public bool InitalImportHasBeenShown
+        {
+            get
+            {
+                return _settings.initalImportHasBeenShown;
+            }
+
+            set
+            {
+                _settings.initalImportHasBeenShown = value;
+                _settings.Save();
+            }
+        }
+
         public DukeboxUserSettings()
         {
             _settings = Settings.Default;

--- a/Dukebox.Desktop/Interfaces/IDukeboxUserSettings.cs
+++ b/Dukebox.Desktop/Interfaces/IDukeboxUserSettings.cs
@@ -8,5 +8,6 @@ namespace Dukebox.Desktop.Interfaces
         bool RepeatAll { get; set; }
         bool Shuffle { get; set; }
         List<string> ExtendedMetadataColumnsToShow { get; set; }
+        bool InitalImportHasBeenShown { get; set; }
     }
 }

--- a/Dukebox.Desktop/Interfaces/IInitalImportWindowViewModel.cs
+++ b/Dukebox.Desktop/Interfaces/IInitalImportWindowViewModel.cs
@@ -7,8 +7,8 @@ namespace Dukebox.Desktop.Interfaces
         string ImportPath { get; }
         string NotificationText { get; }
         string StatusText { get; }
-        int MaximumProgressValue { get; }
-        int CurrentProgressValue { get; }
+        double MaximumProgressValue { get; }
+        double CurrentProgressValue { get; }
         bool ImportHasNotStarted { get; }
         ICommand SelectImportPath { get; }
         ICommand Import { get; }

--- a/Dukebox.Desktop/Interfaces/IInitalImportWindowViewModel.cs
+++ b/Dukebox.Desktop/Interfaces/IInitalImportWindowViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows.Input;
+
+namespace Dukebox.Desktop.Interfaces
+{
+    public interface IInitalImportWindowViewModel
+    {
+        string ImportPath { get; }
+        string NotificationText { get; }
+        string StatusText { get; }
+        int MaximumProgressValue { get; }
+        int CurrentProgressValue { get; }
+        bool ImportHasNotStarted { get; }
+        ICommand SelectImportPath { get; }
+        ICommand Import { get; }
+        ICommand SkipImport { get; }
+    }
+}

--- a/Dukebox.Desktop/Interfaces/IProgressMonitorViewModel.cs
+++ b/Dukebox.Desktop/Interfaces/IProgressMonitorViewModel.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Dukebox.Desktop.Interfaces
+﻿namespace Dukebox.Desktop.Interfaces
 {
     public interface IProgressMonitorViewModel
     {

--- a/Dukebox.Desktop/LoadingScreen.xaml
+++ b/Dukebox.Desktop/LoadingScreen.xaml
@@ -9,7 +9,8 @@
         Title="Dukebox" 
         Height="180" 
         Width="600" 
-        WindowStyle="None" WindowStartupLocation="CenterScreen">
+        WindowStyle="None" 
+        WindowStartupLocation="CenterScreen">
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Loaded">
             <i:InvokeCommandAction Command="{Binding LoadComponents}" />

--- a/Dukebox.Desktop/MainWindow.xaml.cs
+++ b/Dukebox.Desktop/MainWindow.xaml.cs
@@ -2,7 +2,6 @@
 using MahApps.Metro.Controls;
 using Dukebox.Desktop.Interfaces;
 using Dukebox.Desktop.Model;
-using System.Windows.Controls;
 
 namespace Dukebox.Desktop
 {

--- a/Dukebox.Desktop/Model/NotificationMessages.cs
+++ b/Dukebox.Desktop/Model/NotificationMessages.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Dukebox.Desktop.Model
+﻿namespace Dukebox.Desktop.Model
 {
     public static class NotificationMessages
     {
@@ -13,5 +7,6 @@ namespace Dukebox.Desktop.Model
         public const string LoadingScreenShouldHide = "LoadingScreenShouldHide";
         public const string LoadingScreenShouldClose = "LoadingScreenShouldClose";
         public const string TrackListingDataGridColumnsUpdated = "TrackListingDataGridColumnsUpdated";
+        public const string IntialImportWindowShouldClose = "IntialImportWindowShouldClose";
     }
 }

--- a/Dukebox.Desktop/Properties/Settings.Designer.cs
+++ b/Dukebox.Desktop/Properties/Settings.Designer.cs
@@ -70,5 +70,17 @@ namespace Dukebox.Desktop.Properties {
                 this["extendedMetadataColumnsToShow"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool initalImportHasBeenShown {
+            get {
+                return ((bool)(this["initalImportHasBeenShown"]));
+            }
+            set {
+                this["initalImportHasBeenShown"] = value;
+            }
+        }
     }
 }

--- a/Dukebox.Desktop/Properties/Settings.settings
+++ b/Dukebox.Desktop/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="extendedMetadataColumnsToShow" Type="System.String" Scope="User">
       <Value Profile="(Default)">Year</Value>
     </Setting>
+    <Setting Name="initalImportHasBeenShown" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Dukebox.Desktop/ViewModel/InitalImportWindowViewModel.cs
+++ b/Dukebox.Desktop/ViewModel/InitalImportWindowViewModel.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Windows.Forms;
+using System.Windows.Input;
+using GalaSoft.MvvmLight.Command;
+using Dukebox.Desktop.Interfaces;
+using Dukebox.Desktop.Model;
+
+namespace Dukebox.Desktop.ViewModel
+{
+    public class InitalImportWindowViewModel : ViewModelBase, IInitalImportWindowViewModel
+    {
+        private const string importFolderDialogDescription = "Select a folder to import into your music library";
+
+        private readonly IDukeboxUserSettings _userSettings;
+        private readonly FolderBrowserDialog _selectMusicFolderDialog;
+
+        private string _initalImportPath;
+        private string _notificationText;
+        private int _currentProgressValue;
+        private int _maximumProgressValue;
+        private bool _importStarted;
+        private string _statusText;
+
+        public string ImportPath
+        {
+            get
+            {
+                return _initalImportPath;
+            }
+            private set
+            {
+                _initalImportPath = value;
+
+                OnPropertyChanged(nameof(ImportPath));
+            }
+        }
+
+        public string NotificationText
+        {
+            get
+            {
+                return _notificationText;
+            }
+            private set
+            {
+                _notificationText = value;
+
+                OnPropertyChanged(nameof(NotificationText));
+            }
+        }
+
+        public int CurrentProgressValue
+        {
+            get
+            {
+                return _currentProgressValue;
+            }
+            private set
+            {
+                _currentProgressValue = value;
+
+                OnPropertyChanged(nameof(CurrentProgressValue));
+            }
+        }
+
+        public int MaximumProgressValue
+        {
+            get
+            {
+                return _maximumProgressValue;
+            }
+            private set
+            {
+                _maximumProgressValue = value;
+
+                OnPropertyChanged(nameof(MaximumProgressValue));
+            }
+        }
+
+        public bool ImportHasNotStarted
+        {
+            get
+            {
+                return !_importStarted;
+            }
+            private set
+            {
+                _importStarted = !value;
+
+                OnPropertyChanged(nameof(ImportHasNotStarted));
+            }
+        }
+
+        public string StatusText
+        {
+            get
+            {
+                return _statusText;
+            }
+            private set
+            {
+                _statusText = value;
+
+                OnPropertyChanged(nameof(StatusText));
+            }
+        }
+
+        public ICommand SelectImportPath { get; private set; }
+
+        public ICommand Import { get; private set; }
+
+        public ICommand SkipImport { get; private set; }
+
+        public InitalImportWindowViewModel(IDukeboxUserSettings userSettings)
+        {
+            var userMusicFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyMusic);
+
+            _userSettings = userSettings;
+
+            _selectMusicFolderDialog = new FolderBrowserDialog
+            {
+                Description = importFolderDialogDescription,
+                SelectedPath = userMusicFolder
+            };
+
+            ImportPath = userMusicFolder;
+
+            CurrentProgressValue = 0;
+            MaximumProgressValue = 100;
+
+            SelectImportPath = new RelayCommand(DoSelectImportPath);
+            Import = new RelayCommand(DoInitalImport);
+            SkipImport = new RelayCommand(FinishInitalImport);
+        }
+
+        private void DoSelectImportPath()
+        {
+            var dialogResult = _selectMusicFolderDialog.ShowDialog();
+
+            if (dialogResult != DialogResult.OK)
+            {
+                return;
+            }
+
+            ImportPath = _selectMusicFolderDialog.SelectedPath;
+        }
+
+        private void DoInitalImport()
+        {
+            // TODO: Import Logic
+
+            FinishInitalImport();
+        }
+        
+        private void FinishInitalImport()
+        {
+            _userSettings.InitalImportHasBeenShown = true;
+
+            SendNotificationMessage(NotificationMessages.LoadingFinished);
+            SendNotificationMessage(NotificationMessages.IntialImportWindowShouldClose);
+        }
+    }
+}

--- a/Dukebox.Desktop/ViewModel/LoadingScreenViewModel.cs
+++ b/Dukebox.Desktop/ViewModel/LoadingScreenViewModel.cs
@@ -6,12 +6,10 @@ using System.Windows;
 using System.Windows.Input;
 using log4net;
 using GalaSoft.MvvmLight.Command;
-using GalaSoft.MvvmLight.Messaging;
-using Dukebox.Desktop.Helper;
 using Dukebox.Desktop.Interfaces;
-using System.Threading;
 using Dukebox.Desktop.Model;
 using Dukebox.Library.Helper;
+using Dukebox.Desktop.Views;
 
 namespace Dukebox.Desktop.ViewModel
 {
@@ -20,6 +18,7 @@ namespace Dukebox.Desktop.ViewModel
         private static readonly ILog logger = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
         private readonly DukeboxInitialisationHelper _initHelper;
+        private readonly IDukeboxUserSettings _userSettings;
 
         private string _notification;
 
@@ -40,9 +39,11 @@ namespace Dukebox.Desktop.ViewModel
 
         public ICommand LoadComponents { get; }
 
-        public LoadingScreenViewModel(DukeboxInitialisationHelper DukeboxInitialisationHelper)
+        public LoadingScreenViewModel(DukeboxInitialisationHelper DukeboxInitialisationHelper, IDukeboxUserSettings userSettings)
         {
             _initHelper = DukeboxInitialisationHelper;
+            _userSettings = userSettings;
+
             LoadComponents = new RelayCommand(() => Task.Run(() => DoLoadComponents()));
         }
         
@@ -79,8 +80,22 @@ namespace Dukebox.Desktop.ViewModel
                 Application.Current.Shutdown();
             }
 
+            if (!_userSettings.InitalImportHasBeenShown)
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    var initalImportWindow = new InitalImportWindow();
+                    initalImportWindow.Show();
+                });
+            }
+
             SendNotificationMessage(NotificationMessages.LoadingScreenShouldHide);
-            SendNotificationMessage(NotificationMessages.LoadingFinished);
+
+            if (_userSettings.InitalImportHasBeenShown)
+            {
+                SendNotificationMessage(NotificationMessages.LoadingFinished);
+            }
+
             SendNotificationMessage(NotificationMessages.LoadingScreenShouldClose);
         }
     }

--- a/Dukebox.Desktop/ViewModel/ViewModelLocator.cs
+++ b/Dukebox.Desktop/ViewModel/ViewModelLocator.cs
@@ -12,6 +12,14 @@ namespace Dukebox.Desktop.ViewModel
             }
         }
 
+        public IInitalImportWindowViewModel InitalImportViewModel
+        {
+            get
+            {
+                return DesktopContainer.GetInstance<IInitalImportWindowViewModel>();
+            }
+        }
+
         // window view model
         public IMainWindowViewModel MainWindow
         {

--- a/Dukebox.Desktop/Views/InitalImportWindow.xaml
+++ b/Dukebox.Desktop/Views/InitalImportWindow.xaml
@@ -4,11 +4,12 @@
         Icon="..\app.ico"
         WindowStartupLocation="CenterScreen"
         Title="Dukebox - Welcome" 
-        Height="280" 
-        Width="550" 
+        Height="300" 
+        Width="600" 
         WindowStyle="ToolWindow"
+        Closing="Window_Closing"
         DataContext="{Binding InitalImportViewModel, Source={StaticResource ViewModelLocator}}">
-    <Grid>
+    <Grid Margin="2">
         <Grid.RowDefinitions>
             <RowDefinition Height="0.4*"></RowDefinition>
             <RowDefinition Height="0.1*"></RowDefinition>
@@ -28,7 +29,7 @@
                 <ColumnDefinition Width="0.3*"></ColumnDefinition>
                 <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <Image Grid.Row="0" Grid.Column="0" Source="..\app.ico" Stretch="Uniform" Margin="5"></Image>
+            <Image Grid.Row="0" Grid.Column="0" Source="..\Graphics\app.png" Stretch="Uniform" Margin="5"></Image>
             <Grid Grid.Row="0" Grid.Column="1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="2*"></RowDefinition>
@@ -48,12 +49,12 @@
                            Grid.Column="0" 
                            Margin="2" 
                            FontSize="14" 
-                           Text="To get started, browse for a folder you keep music in to add songs to your music library." 
+                           Text="To get started, browse for a folder you keep music in to add songs to your music library" 
                            TextAlignment="Left"
                            TextWrapping="Wrap"/>
                 <TextBlock Grid.Row="2"
                            Grid.Column="0"
-                           FontSize="10" 
+                           FontSize="11" 
                            Margin="2"
                            TextAlignment="Right">
                     <Hyperlink Command="{Binding SkipImport}">Skip Inital Import</Hyperlink>
@@ -77,6 +78,6 @@
         </StackPanel>
         <Separator Grid.Row="3" Grid.Column="0"></Separator>
         <ProgressBar Grid.Row="4" Grid.Column="0" Margin="2" Maximum="{Binding MaximumProgressValue}" Value="{Binding CurrentProgressValue, Mode=OneWay}"></ProgressBar>
-        <TextBlock Grid.Row="5" Grid.Column="0" FontSize="14" Text="{Binding StatusText}" TextAlignment="Right"></TextBlock>
+        <TextBlock Grid.Row="5" Grid.Column="0" FontSize="14" Text="{Binding NotificationText}" TextAlignment="Left"></TextBlock>
     </Grid>
 </Window>

--- a/Dukebox.Desktop/Views/InitalImportWindow.xaml
+++ b/Dukebox.Desktop/Views/InitalImportWindow.xaml
@@ -1,0 +1,82 @@
+﻿<Window x:Class="Dukebox.Desktop.Views.InitalImportWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Icon="..\app.ico"
+        WindowStartupLocation="CenterScreen"
+        Title="Dukebox - Welcome" 
+        Height="280" 
+        Width="550" 
+        WindowStyle="ToolWindow"
+        DataContext="{Binding InitalImportViewModel, Source={StaticResource ViewModelLocator}}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="0.4*"></RowDefinition>
+            <RowDefinition Height="0.1*"></RowDefinition>
+            <RowDefinition Height="0.1*"></RowDefinition>
+            <RowDefinition Height="0.1*"></RowDefinition>
+            <RowDefinition Height="0.1*"></RowDefinition>
+            <RowDefinition Height="0.1*"></RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"></ColumnDefinition>
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Row="0" Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="0.3*"></ColumnDefinition>
+                <ColumnDefinition Width="*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Image Grid.Row="0" Grid.Column="0" Source="..\app.ico" Stretch="Uniform" Margin="5"></Image>
+            <Grid Grid.Row="0" Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="2*"></RowDefinition>
+                    <RowDefinition Height="3*"></RowDefinition>
+                    <RowDefinition Height="*"></RowDefinition>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Row="0" 
+                           Grid.Column="0" 
+                           Margin="2" 
+                           FontSize="14" 
+                           Text="Thanks for Downloading Dukebox" 
+                           TextAlignment="Left"/>
+                <TextBlock Grid.Row="1" 
+                           Grid.Column="0" 
+                           Margin="2" 
+                           FontSize="14" 
+                           Text="To get started, browse for a folder you keep music in to add songs to your music library." 
+                           TextAlignment="Left"
+                           TextWrapping="Wrap"/>
+                <TextBlock Grid.Row="2"
+                           Grid.Column="0"
+                           FontSize="10" 
+                           Margin="2"
+                           TextAlignment="Right">
+                    <Hyperlink Command="{Binding SkipImport}">Skip Inital Import</Hyperlink>
+                </TextBlock>
+            </Grid>
+        </Grid>
+        <Grid Grid.Row="1" Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width=".09*"></ColumnDefinition>
+                <ColumnDefinition Width="*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Label Grid.Row="0" Grid.Column="0">Folder: </Label>
+            <TextBox Grid.Row="0" Grid.Column="1" IsEnabled="False" Text="{Binding ImportPath, Mode=OneWay}" Margin="1"></TextBox>
+        </Grid>
+        <StackPanel Grid.Row="2" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Command="{Binding SelectImportPath}" IsEnabled="{Binding ImportHasNotStarted}" Margin="1">Browse</Button>
+            <Button Command="{Binding Import}" IsEnabled="{Binding ImportHasNotStarted}" Margin="1">Import</Button>
+        </StackPanel>
+        <Separator Grid.Row="3" Grid.Column="0"></Separator>
+        <ProgressBar Grid.Row="4" Grid.Column="0" Margin="2" Maximum="{Binding MaximumProgressValue}" Value="{Binding CurrentProgressValue, Mode=OneWay}"></ProgressBar>
+        <TextBlock Grid.Row="5" Grid.Column="0" FontSize="14" Text="{Binding StatusText}" TextAlignment="Right"></TextBlock>
+    </Grid>
+</Window>

--- a/Dukebox.Desktop/Views/InitalImportWindow.xaml.cs
+++ b/Dukebox.Desktop/Views/InitalImportWindow.xaml.cs
@@ -1,5 +1,7 @@
-﻿using GalaSoft.MvvmLight.Messaging;
+﻿using System;
 using System.Windows;
+using GalaSoft.MvvmLight.Messaging;
+using Dukebox.Desktop.Interfaces;
 using Dukebox.Desktop.Model;
 
 namespace Dukebox.Desktop.Views
@@ -19,10 +21,23 @@ namespace Dukebox.Desktop.Views
                 {
                     if (nm.Notification == NotificationMessages.IntialImportWindowShouldClose)
                     {
-                        Close();
+                        try
+                        {
+                            Close();
+                        }
+                        catch (Exception)
+                        {
+                            // Window is closing already...
+                        }
                     }
                 });
             });
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var viewModel = DataContext as IInitalImportWindowViewModel;
+            viewModel?.SkipImport?.Execute(null);
         }
     }
 }

--- a/Dukebox.Desktop/Views/InitalImportWindow.xaml.cs
+++ b/Dukebox.Desktop/Views/InitalImportWindow.xaml.cs
@@ -1,0 +1,28 @@
+﻿using GalaSoft.MvvmLight.Messaging;
+using System.Windows;
+using Dukebox.Desktop.Model;
+
+namespace Dukebox.Desktop.Views
+{
+    /// <summary>
+    /// Interaction logic for InitalImportWindow.xaml
+    /// </summary>
+    public partial class InitalImportWindow : Window
+    {
+        public InitalImportWindow()
+        {
+            InitializeComponent();
+
+            Messenger.Default.Register<NotificationMessage>(this, (nm) =>
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    if (nm.Notification == NotificationMessages.IntialImportWindowShouldClose)
+                    {
+                        Close();
+                    }
+                });
+            });
+        }
+    }
+}

--- a/Dukebox.Desktop/app.config
+++ b/Dukebox.Desktop/app.config
@@ -28,6 +28,9 @@
       <setting name="extendedMetadataColumnsToShow" serializeAs="String">
         <value>Year</value>
       </setting>
+      <setting name="initalImportHasBeenShown" serializeAs="String">
+        <value>False</value>
+      </setting>
     </Dukebox.Desktop.Properties.Settings>
   </userSettings>
   <entityFramework>

--- a/Dukebox.Library/Dukebox.Library.csproj
+++ b/Dukebox.Library/Dukebox.Library.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Factories\AudioFileMetadataFactory.cs" />
     <Compile Include="Helper\ExtendedMetadataHelper.cs" />
     <Compile Include="Helper\StringToFilenameConverter.cs" />
+    <Compile Include="Helper\TruncatePathHelper.cs" />
     <Compile Include="Interfaces\IMusicLibraryImportService.cs" />
     <Compile Include="Interfaces\IMusicLibraryUpdateService.cs" />
     <Compile Include="Interfaces\IMusicLibraryCacheService.cs" />

--- a/Dukebox.Library/Helper/TruncatePathHelper.cs
+++ b/Dukebox.Library/Helper/TruncatePathHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Dukebox.Library.Helper
+{
+    public static class TruncatePathHelper
+    {
+        public const int TrailingReportCharsToPrint = 50;
+
+        public static string TruncatePath(string path)
+        {
+            var truncatedpath = path.Substring(Math.Max(0, path.Length - TrailingReportCharsToPrint));
+
+            return path.Length > truncatedpath.Length ? $"...{truncatedpath}" : path;
+        }
+    }
+}

--- a/Dukebox.Library/Model/WatchFolderEvent.cs
+++ b/Dukebox.Library/Model/WatchFolderEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Dukebox.Library.Helper;
 
 namespace Dukebox.Library.Model
 {
@@ -16,22 +17,14 @@ namespace Dukebox.Library.Model
 
             if (EventType == WatchFolderEventType.DirectoryImport)
             {
-                msg = $"Imported {ImportReport.NumberOfFilesAdded} songs from directory {TruncatePath(ImportReport.DirectoryPath)}";
+                msg = $"Imported {ImportReport.NumberOfFilesAdded} songs from directory {TruncatePathHelper.TruncatePath(ImportReport.DirectoryPath)}";
             }
             else
             {
-                msg = $"{AudioFileImportInfo.Status} file {TruncatePath(AudioFileImportInfo.FileAdded)}";
+                msg = $"{AudioFileImportInfo.Status} file {TruncatePathHelper.TruncatePath(AudioFileImportInfo.FileAdded)}";
             }
 
             return $"{ImportReport?.ImportDateTime ?? DateTime.UtcNow} - {msg}";
-        }
-
-
-        private string TruncatePath(string path)
-        { 
-            var truncatedpath = path.Substring(Math.Max(0, path.Length - trailingReportCharsToPrint));
-
-            return path.Length > truncatedpath.Length ? $"...{truncatedpath}" : path;
         }
     }
 }


### PR DESCRIPTION
- Presents one time only on initial program start after install (once per user)
- Option to browse for initial import folder and import tracks (Defaults to users music folder)
- Controls to monitor import progress
- Option to skip by clicking link in window or by closing window
